### PR TITLE
delayedInit() relies on toBeDestroyed.length value to be 0. Otherwise…

### DIFF
--- a/src/includes/libraries/cmb2/js/cmb2-wysiwyg.js
+++ b/src/includes/libraries/cmb2/js/cmb2-wysiwyg.js
@@ -46,6 +46,8 @@ window.CMB2.wysiwyg = window.CMB2.wysiwyg || {};
 			toBeDestroyed.splice( toBeDestroyed.indexOf( id ), 1 );
 			wysiwyg.destroy( id );
 		} );
+                
+                toBeDestroyed = [];
 	}
 
 	/**


### PR DESCRIPTION
…, it will generate an infinite loop

<!--
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
 -->

### Description
<!-- We must be able to understand the design of your change from this description. -->
When working on a Project on wp-admin, a user is capable to shift a Milestone, Task, or Bug up or down in case the order does not look right.

Due to the Notes field that uses TinyMCE, CMB2 needs to destroy TinyMCE on shiftStart and reinitialize on shiftComplete.

Some TinyMCE instances could fall through the crack and be queued for a delayed destroy. Even though a delayedDestroy is only executed once after a 100s delay, there is a chance that it can still leave a TinyMCE instance in the toBeDestroyed array. If toBeDestroyed array does not get to 0, the delayedInit will create one infinite loop.

Potentially, a user can create more than one infinite loops and crash his/her browser just by shifting a Milestone, Task, or Bug.

### Benefits
<!-- What benefits will be realized the code changes? -->
Faster and more predictable Project page on wp-admin.

### Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->
CMB2 modification. Also, the change on cmb2-wysiwyg.js needs to be incorporated and minified into cmb2.min.js.

### Applicable issues
<!-- Link any applicable Issues here -->
#261 